### PR TITLE
Reformat

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -40,7 +40,7 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
 BreakConstructorInitializersBeforeComma: false
 BreakStringLiterals: true
-ColumnLimit: 120
+ColumnLimit: 80
 CommentPragmas: '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,7 +27,90 @@ CheckOptions:
   - key: readability-identifier-length.IgnoredParameterNames
     value: 'x|y|z'
 
+# Identifier Naming Conventions
+  
+# Class : ClassName
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
 
+# Class Member : class_member_name_
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           lower_case
+  - key:             readability-identifier-naming.ClassMemberSuffix
+    value:           _
 
+# Const Expression Variable : CONST_EXPRESSION_VARIABLE_NAME
+  - key:             readability-identifier-naming.ConstexprVariableCase
+    value:           UPPER_CASE
 
+# Enum : EnumName
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
 
+# Enum Constant : ENUM_CONSTANT_NAME
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           UPPER_CASE
+
+# Function : functionName
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+
+# Global Constant : GLOBAL_CONSTANT_NAME 
+  - key:             readability-identifier-naming.GlobalConstantCase
+    value:           UPPER_CASE
+
+# Static Constant : STATIC_CONSTANT_NAME
+  - key:             readability-identifier-naming.StaticConstantCase
+    value:           UPPER_CASE
+
+# Static Variable : static_variable_name
+  - key:             readability-identifier-naming.StaticVariableCase
+    value:           lower_case
+
+# Macro Definition: MACRO_DEFINITION_NAME or MACRO_DEFINITION_NAME_
+  - key:             readability-identifier-naming.MacroDefinitionCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.MacroDefinitionIgnoredRegexp
+    value:           '^[A-Z]+(_[A-Z]+)*_$'
+
+# Private Member : private_member_name_
+  - key:             readability-identifier-naming.PrivateMemberCase
+    value:           lower_case
+  - key:             readability-identifier-naming.PrivateMemberSuffix
+    value:           _
+
+# Protected Member : protected_member_name_
+  - key:             readability-identifier-naming.ProtectedMemberCase
+    value:           lower_case
+  - key:             readability-identifier-naming.ProtectedMemberSuffix
+    value:           _
+
+# Public Member : public_member_name
+  - key:             readability-identifier-naming.PublicMemberCase
+    value:           lower_case
+  - key:             readability-identifier-naming.PublicMemberSuffix
+    value:           ''
+
+# Namespace : namespace_name
+  - key:             readability-identifier-naming.NamespaceCase
+    value:           lower_case
+
+# Parameter : parameter_name
+  - key:             readability-identifier-naming.ParameterCase
+    value:           lower_case
+
+# Type Alias : TypeAliasName
+  - key:             readability-identifier-naming.TypeAliasCase
+    value:           CamelCase
+
+# Typedef : TypedefName
+  - key:             readability-identifier-naming.TypedefCase
+    value:           CamelCase
+
+# Variable : variable_name
+  - key:             readability-identifier-naming.VariableCase
+    value:           lower_case
+
+# Ignore main-like functions
+  - key:             readability-identifier-naming.IgnoreMainLikeFunctions
+    value:           1

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -11,7 +11,7 @@ bullet_char: '*'
 dangle_parens: false
 enum_char: .
 line_ending: unix
-line_width: 120
+line_width: 80
 max_pargs_hwrap: 3
 separate_ctrl_name_with_space: false
 separate_fn_name_with_space: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,18 +5,17 @@ cmake_minimum_required(VERSION 3.21)
 # manual dependency management
 
 # Only set the cxx_standard if it is not set by someone else
-if (NOT DEFINED CMAKE_CXX_STANDARD)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 20)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-  if (APPLE AND CMAKE_OSX_SYSROOT STREQUAL "")
+  if(APPLE AND CMAKE_OSX_SYSROOT STREQUAL "")
     message(STATUS "Determining SDK path using xcrun")
     execute_process(
       COMMAND xcrun --show-sdk-path
       OUTPUT_VARIABLE SDK_PATH
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    if (SDK_PATH)
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(SDK_PATH)
       message(STATUS "Setting CMAKE_OSX_SYSROOT to ${SDK_PATH}")
       set(CMAKE_OSX_SYSROOT "${SDK_PATH}")
     else()
@@ -31,16 +30,23 @@ endif()
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Profiling enable if requested
-if (Clock_ENABLE_PROFILING)
+if(Clock_ENABLE_PROFILING)
   message(STATUS "Profiling enabled, using -pg for profiling support")
-  if (DEFINED CMAKE_BUILD_TYPE AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-    message(WARNING "Profiling is enabled, but you are building in Debug mode. This may not give you the results you expect. Consider using Release or RelWithDebInfo instead.")
+  if(DEFINED CMAKE_BUILD_TYPE AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(
+      WARNING
+        "Profiling is enabled, but you are building in Debug mode. This may not give you the results you expect. Consider using Release or RelWithDebInfo instead."
+    )
   endif()
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL
+                                             "Clang")
     add_compile_options(-pg)
     add_link_options(-pg)
   else()
-    message(WARNING "Profiling is enabled, but the current compiler does not support the -pg flag. Skipping profiling flags.")
+    message(
+      WARNING
+        "Profiling is enabled, but the current compiler does not support the -pg flag. Skipping profiling flags."
+    )
   endif()
 endif()
 
@@ -55,14 +61,13 @@ project(
 include(cmake/PreventInSourceBuilds.cmake)
 include(ProjectOptions.cmake)
 
+clock_setup_options()
 
-Clock_setup_options()
-
-Clock_global_options()
+clock_global_options()
 include(Dependencies.cmake)
-Clock_setup_dependencies()
+clock_setup_dependencies()
 
-Clock_local_options()
+clock_local_options()
 
 # don't know if this should be set globally from here or not...
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
@@ -99,14 +104,19 @@ endif()
 include(CTest)
 
 if(BUILD_TESTING)
-  message(AUTHOR_WARNING "Building Tests. Be sure to check out test/constexpr_tests.cpp for constexpr testing")
+  message(
+    AUTHOR_WARNING
+      "Building Tests. Be sure to check out test/constexpr_tests.cpp for constexpr testing"
+  )
   add_subdirectory(test)
 endif()
 
-
 if(Clock_BUILD_FUZZ_TESTS)
-  message(AUTHOR_WARNING "Building Fuzz Tests, using fuzzing sanitizer https://www.llvm.org/docs/LibFuzzer.html")
-  if (NOT Clock_ENABLE_SANITIZER_ADDRESS AND NOT Clock_ENABLE_SANITIZER_THREAD)
+  message(
+    AUTHOR_WARNING
+      "Building Fuzz Tests, using fuzzing sanitizer https://www.llvm.org/docs/LibFuzzer.html"
+  )
+  if(NOT Clock_ENABLE_SANITIZER_ADDRESS AND NOT Clock_ENABLE_SANITIZER_THREAD)
     message(WARNING "You need asan or tsan enabled for meaningful fuzz testing")
   endif()
   add_subdirectory(fuzz_test)
@@ -118,7 +128,9 @@ endif()
 if(MSVC)
   get_all_installable_targets(all_targets)
   message("all_targets=${all_targets}")
-  set_target_properties(${all_targets} PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=$(VC_ExecutablePath_x64);%PATH%")
+  set_target_properties(
+    ${all_targets} PROPERTIES VS_DEBUGGER_ENVIRONMENT
+                              "PATH=$(VC_ExecutablePath_x64);%PATH%")
 endif()
 
 # set the startup project for the "play" button in MSVC
@@ -132,7 +144,7 @@ include(cmake/PackageProject.cmake)
 
 # Add other targets that you want installed here, by default we just package the one executable
 # we know we want to ship
-Clock_package_project(
+clock_package_project(
   TARGETS
   intro
   Clock_options

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,7 +12,10 @@
             "hidden": true,
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/out/build/${presetName}",
-            "installDir": "${sourceDir}/out/install/${presetName}"
+            "installDir": "${sourceDir}/out/install/${presetName}",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            }
         },
         {
             "name": "conf-windows-common",

--- a/ProjectOptions.cmake
+++ b/ProjectOptions.cmake
@@ -127,6 +127,10 @@ macro(Clock_setup_options)
       Clock_ENABLE_CACHE)
   endif()
 
+  if(PROJECT_IS_TOP_LEVEL)
+    set(Clock_ENABLE_Doxygen ON)
+  endif()
+
   clock_check_libfuzzer_support(LIBFUZZER_SUPPORTED)
   if(LIBFUZZER_SUPPORTED
      AND (Clock_ENABLE_SANITIZER_ADDRESS
@@ -139,7 +143,6 @@ macro(Clock_setup_options)
 
   option(Clock_BUILD_FUZZ_TESTS "Enable fuzz testing executable"
          ${DEFAULT_FUZZER})
-
 endmacro()
 
 macro(Clock_global_options)
@@ -152,6 +155,7 @@ macro(Clock_global_options)
 
   if(Clock_ENABLE_HARDENING AND Clock_ENABLE_GLOBAL_HARDENING)
     include(cmake/Hardening.cmake)
+
     if(NOT SUPPORTS_UBSAN
        OR Clock_ENABLE_SANITIZER_UNDEFINED
        OR Clock_ENABLE_SANITIZER_ADDRESS
@@ -161,6 +165,7 @@ macro(Clock_global_options)
     else()
       set(ENABLE_UBSAN_MINIMAL_RUNTIME TRUE)
     endif()
+
     message(
       "${Clock_ENABLE_HARDENING} ${ENABLE_UBSAN_MINIMAL_RUNTIME} ${Clock_ENABLE_SANITIZER_UNDEFINED}"
     )
@@ -216,7 +221,14 @@ macro(Clock_local_options)
     clock_enable_cache()
   endif()
 
+  include(cmake/Doxygen.cmake)
+
+  if(Clock_ENABLE_Doxygen)
+    clock_enable_doxygen("awesome-sidebar")
+  endif()
+
   include(cmake/StaticAnalyzers.cmake)
+
   if(Clock_ENABLE_CLANG_TIDY)
     clock_enable_clang_tidy(Clock_options ${Clock_WARNINGS_AS_ERRORS})
   endif()
@@ -234,6 +246,7 @@ macro(Clock_local_options)
 
   if(Clock_WARNINGS_AS_ERRORS)
     check_cxx_compiler_flag("-Wl,--fatal-warnings" LINKER_FATAL_WARNINGS)
+
     if(LINKER_FATAL_WARNINGS)
       # This is not working consistently, so disabling for now
       # target_link_options(Clock_options INTERFACE -Wl,--fatal-warnings)

--- a/ProjectOptions.cmake
+++ b/ProjectOptions.cmake
@@ -3,14 +3,16 @@ include(cmake/LibFuzzer.cmake)
 include(CMakeDependentOption)
 include(CheckCXXCompilerFlag)
 
-
 include(CheckCXXSourceCompiles)
 
-
 macro(Clock_supports_sanitizers)
-  if((CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*" OR CMAKE_CXX_COMPILER_ID MATCHES ".*GNU.*") AND NOT WIN32)
+  if((CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*" OR CMAKE_CXX_COMPILER_ID MATCHES
+                                                   ".*GNU.*") AND NOT WIN32)
 
-    message(STATUS "Sanity checking UndefinedBehaviorSanitizer, it should be supported on this platform")
+    message(
+      STATUS
+        "Sanity checking UndefinedBehaviorSanitizer, it should be supported on this platform"
+    )
     set(TEST_PROGRAM "int main() { return 0; }")
 
     # Check if UndefinedBehaviorSanitizer works at link time
@@ -19,21 +21,29 @@ macro(Clock_supports_sanitizers)
     check_cxx_source_compiles("${TEST_PROGRAM}" HAS_UBSAN_LINK_SUPPORT)
 
     if(HAS_UBSAN_LINK_SUPPORT)
-      message(STATUS "UndefinedBehaviorSanitizer is supported at both compile and link time.")
+      message(
+        STATUS
+          "UndefinedBehaviorSanitizer is supported at both compile and link time."
+      )
       set(SUPPORTS_UBSAN ON)
     else()
-      message(WARNING "UndefinedBehaviorSanitizer is NOT supported at link time.")
+      message(
+        WARNING "UndefinedBehaviorSanitizer is NOT supported at link time.")
       set(SUPPORTS_UBSAN OFF)
     endif()
   else()
     set(SUPPORTS_UBSAN OFF)
   endif()
 
-  if((CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*" OR CMAKE_CXX_COMPILER_ID MATCHES ".*GNU.*") AND WIN32)
+  if((CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*" OR CMAKE_CXX_COMPILER_ID MATCHES
+                                                   ".*GNU.*") AND WIN32)
     set(SUPPORTS_ASAN OFF)
   else()
-    if (NOT WIN32)
-      message(STATUS "Sanity checking AddressSanitizer, it should be supported on this platform")
+    if(NOT WIN32)
+      message(
+        STATUS
+          "Sanity checking AddressSanitizer, it should be supported on this platform"
+      )
       set(TEST_PROGRAM "int main() { return 0; }")
 
       # Check if AddressSanitizer works at link time
@@ -42,7 +52,8 @@ macro(Clock_supports_sanitizers)
       check_cxx_source_compiles("${TEST_PROGRAM}" HAS_ASAN_LINK_SUPPORT)
 
       if(HAS_ASAN_LINK_SUPPORT)
-        message(STATUS "AddressSanitizer is supported at both compile and link time.")
+        message(
+          STATUS "AddressSanitizer is supported at both compile and link time.")
         set(SUPPORTS_ASAN ON)
       else()
         message(WARNING "AddressSanitizer is NOT supported at link time.")
@@ -64,7 +75,7 @@ macro(Clock_setup_options)
     Clock_ENABLE_HARDENING
     OFF)
 
-  Clock_supports_sanitizers()
+  clock_supports_sanitizers()
 
   if(NOT PROJECT_IS_TOP_LEVEL OR Clock_PACKAGING_MAINTAINER_MODE)
     option(Clock_ENABLE_IPO "Enable IPO/LTO" OFF)
@@ -84,9 +95,11 @@ macro(Clock_setup_options)
     option(Clock_ENABLE_IPO "Enable IPO/LTO" ON)
     option(Clock_WARNINGS_AS_ERRORS "Treat Warnings As Errors" ON)
     option(Clock_ENABLE_USER_LINKER "Enable user-selected linker" OFF)
-    option(Clock_ENABLE_SANITIZER_ADDRESS "Enable address sanitizer" ${SUPPORTS_ASAN})
+    option(Clock_ENABLE_SANITIZER_ADDRESS "Enable address sanitizer"
+           ${SUPPORTS_ASAN})
     option(Clock_ENABLE_SANITIZER_LEAK "Enable leak sanitizer" OFF)
-    option(Clock_ENABLE_SANITIZER_UNDEFINED "Enable undefined sanitizer" ${SUPPORTS_UBSAN})
+    option(Clock_ENABLE_SANITIZER_UNDEFINED "Enable undefined sanitizer"
+           ${SUPPORTS_UBSAN})
     option(Clock_ENABLE_SANITIZER_THREAD "Enable thread sanitizer" OFF)
     option(Clock_ENABLE_SANITIZER_MEMORY "Enable memory sanitizer" OFF)
     option(Clock_ENABLE_UNITY_BUILD "Enable unity builds" OFF)
@@ -114,28 +127,32 @@ macro(Clock_setup_options)
       Clock_ENABLE_CACHE)
   endif()
 
-  Clock_check_libfuzzer_support(LIBFUZZER_SUPPORTED)
-  if(LIBFUZZER_SUPPORTED AND (Clock_ENABLE_SANITIZER_ADDRESS OR Clock_ENABLE_SANITIZER_THREAD OR Clock_ENABLE_SANITIZER_UNDEFINED))
+  clock_check_libfuzzer_support(LIBFUZZER_SUPPORTED)
+  if(LIBFUZZER_SUPPORTED
+     AND (Clock_ENABLE_SANITIZER_ADDRESS
+          OR Clock_ENABLE_SANITIZER_THREAD
+          OR Clock_ENABLE_SANITIZER_UNDEFINED))
     set(DEFAULT_FUZZER ON)
   else()
     set(DEFAULT_FUZZER OFF)
   endif()
 
-  option(Clock_BUILD_FUZZ_TESTS "Enable fuzz testing executable" ${DEFAULT_FUZZER})
+  option(Clock_BUILD_FUZZ_TESTS "Enable fuzz testing executable"
+         ${DEFAULT_FUZZER})
 
 endmacro()
 
 macro(Clock_global_options)
   if(Clock_ENABLE_IPO)
     include(cmake/InterproceduralOptimization.cmake)
-    Clock_enable_ipo()
+    clock_enable_ipo()
   endif()
 
-  Clock_supports_sanitizers()
+  clock_supports_sanitizers()
 
   if(Clock_ENABLE_HARDENING AND Clock_ENABLE_GLOBAL_HARDENING)
     include(cmake/Hardening.cmake)
-    if(NOT SUPPORTS_UBSAN 
+    if(NOT SUPPORTS_UBSAN
        OR Clock_ENABLE_SANITIZER_UNDEFINED
        OR Clock_ENABLE_SANITIZER_ADDRESS
        OR Clock_ENABLE_SANITIZER_THREAD
@@ -144,8 +161,10 @@ macro(Clock_global_options)
     else()
       set(ENABLE_UBSAN_MINIMAL_RUNTIME TRUE)
     endif()
-    message("${Clock_ENABLE_HARDENING} ${ENABLE_UBSAN_MINIMAL_RUNTIME} ${Clock_ENABLE_SANITIZER_UNDEFINED}")
-    Clock_enable_hardening(Clock_options ON ${ENABLE_UBSAN_MINIMAL_RUNTIME})
+    message(
+      "${Clock_ENABLE_HARDENING} ${ENABLE_UBSAN_MINIMAL_RUNTIME} ${Clock_ENABLE_SANITIZER_UNDEFINED}"
+    )
+    clock_enable_hardening(Clock_options ON ${ENABLE_UBSAN_MINIMAL_RUNTIME})
   endif()
 endmacro()
 
@@ -158,7 +177,7 @@ macro(Clock_local_options)
   add_library(Clock_options INTERFACE)
 
   include(cmake/CompilerWarnings.cmake)
-  Clock_set_project_warnings(
+  clock_set_project_warnings(
     Clock_warnings
     ${Clock_WARNINGS_AS_ERRORS}
     ""
@@ -168,11 +187,11 @@ macro(Clock_local_options)
 
   if(Clock_ENABLE_USER_LINKER)
     include(cmake/Linker.cmake)
-    Clock_configure_linker(Clock_options)
+    clock_configure_linker(Clock_options)
   endif()
 
   include(cmake/Sanitizers.cmake)
-  Clock_enable_sanitizers(
+  clock_enable_sanitizers(
     Clock_options
     ${Clock_ENABLE_SANITIZER_ADDRESS}
     ${Clock_ENABLE_SANITIZER_LEAK}
@@ -180,7 +199,8 @@ macro(Clock_local_options)
     ${Clock_ENABLE_SANITIZER_THREAD}
     ${Clock_ENABLE_SANITIZER_MEMORY})
 
-  set_target_properties(Clock_options PROPERTIES UNITY_BUILD ${Clock_ENABLE_UNITY_BUILD})
+  set_target_properties(Clock_options PROPERTIES UNITY_BUILD
+                                                 ${Clock_ENABLE_UNITY_BUILD})
 
   if(Clock_ENABLE_PCH)
     target_precompile_headers(
@@ -193,22 +213,23 @@ macro(Clock_local_options)
 
   if(Clock_ENABLE_CACHE)
     include(cmake/Cache.cmake)
-    Clock_enable_cache()
+    clock_enable_cache()
   endif()
 
   include(cmake/StaticAnalyzers.cmake)
   if(Clock_ENABLE_CLANG_TIDY)
-    Clock_enable_clang_tidy(Clock_options ${Clock_WARNINGS_AS_ERRORS})
+    clock_enable_clang_tidy(Clock_options ${Clock_WARNINGS_AS_ERRORS})
   endif()
 
   if(Clock_ENABLE_CPPCHECK)
-    Clock_enable_cppcheck(${Clock_WARNINGS_AS_ERRORS} "" # override cppcheck options
+    clock_enable_cppcheck(
+      ${Clock_WARNINGS_AS_ERRORS} "" # override cppcheck options
     )
   endif()
 
   if(Clock_ENABLE_COVERAGE)
     include(cmake/Tests.cmake)
-    Clock_enable_coverage(Clock_options)
+    clock_enable_coverage(Clock_options)
   endif()
 
   if(Clock_WARNINGS_AS_ERRORS)
@@ -221,7 +242,7 @@ macro(Clock_local_options)
 
   if(Clock_ENABLE_HARDENING AND NOT Clock_ENABLE_GLOBAL_HARDENING)
     include(cmake/Hardening.cmake)
-    if(NOT SUPPORTS_UBSAN 
+    if(NOT SUPPORTS_UBSAN
        OR Clock_ENABLE_SANITIZER_UNDEFINED
        OR Clock_ENABLE_SANITIZER_ADDRESS
        OR Clock_ENABLE_SANITIZER_THREAD
@@ -230,7 +251,7 @@ macro(Clock_local_options)
     else()
       set(ENABLE_UBSAN_MINIMAL_RUNTIME TRUE)
     endif()
-    Clock_enable_hardening(Clock_options OFF ${ENABLE_UBSAN_MINIMAL_RUNTIME})
+    clock_enable_hardening(Clock_options OFF ${ENABLE_UBSAN_MINIMAL_RUNTIME})
   endif()
 
 endmacro()

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## More Details
 
- * [Dependency Setup](README_dependencies.md)
- * [Building Details](README_building.md)
- * [Troubleshooting](README_troubleshooting.md)
+ * [Dependency Setup](./README_dependencies.md)
+ * [Building Details](./README_building.md)
+ <!-- * [Troubleshooting](./README_troubleshooting.md) -->
  * [Docker](README_docker.md)

--- a/README_docker.md
+++ b/README_docker.md
@@ -9,7 +9,7 @@ docker run -it my_project:latest
 ```
 
 This command will put you in a `bash` session in a Ubuntu 20.04 Docker container,
-with all of the tools listed in the [Dependencies](#dependencies) section already installed.
+with all of the tools listed in the [Dependencies](./README_dependencies.md) section already installed.
 Additionally, you will have `g++-11` and `clang++-13` installed as the default
 versions of `g++` and `clang++`.
 
@@ -42,7 +42,7 @@ docker run -it \
 	my_project:latest
 ```
 
-You can configure and build [as directed above](#build) using these commands:
+You can configure and build [as directed above](./README_building.md) using these commands:
 
 ```bash
 /starter_project# mkdir build

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -3,22 +3,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
 
 set(CPM_DOWNLOAD_VERSION 0.40.8)
-set(CPM_HASH_SUM "78ba32abdf798bc616bab7c73aac32a17bbd7b06ad9e26a6add69de8f3ae4791")
+set(CPM_HASH_SUM
+    "78ba32abdf798bc616bab7c73aac32a17bbd7b06ad9e26a6add69de8f3ae4791")
 
 if(CPM_SOURCE_CACHE)
-  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+  set(CPM_DOWNLOAD_LOCATION
+      "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 elseif(DEFINED ENV{CPM_SOURCE_CACHE})
-  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+  set(CPM_DOWNLOAD_LOCATION
+      "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 else()
-  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+  set(CPM_DOWNLOAD_LOCATION
+      "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 endif()
 
 # Expand relative path. This is important if the provided path contains a tilde (~)
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
 
-file(DOWNLOAD
-     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
-     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
-)
+file(
+  DOWNLOAD
+  https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+  ${CPM_DOWNLOAD_LOCATION}
+  EXPECTED_HASH SHA256=${CPM_HASH_SUM})
 
 include(${CPM_DOWNLOAD_LOCATION})

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -28,6 +28,7 @@ function(Clock_enable_cache)
         ${CACHE_BINARY}
         CACHE FILEPATH "C compiler cache used")
   else()
-    message(WARNING "${CACHE_OPTION} is enabled but was not found. Not using it")
+    message(
+      WARNING "${CACHE_OPTION} is enabled but was not found. Not using it")
   endif()
 endfunction()

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -96,7 +96,9 @@ function(
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(PROJECT_WARNINGS_CXX ${GCC_WARNINGS})
   else()
-    message(AUTHOR_WARNING "No compiler warnings set for CXX compiler: '${CMAKE_CXX_COMPILER_ID}'")
+    message(
+      AUTHOR_WARNING
+        "No compiler warnings set for CXX compiler: '${CMAKE_CXX_COMPILER_ID}'")
     # TODO support Intel compiler
   endif()
 

--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -36,7 +36,8 @@ macro(Clock_target_link_cuda target)
   if(APPLE)
     # We need to add the path to the driver (libcuda.dylib) as an rpath,
     # so that the static cuda runtime can find it at runtime.
-    set_property(TARGET ${target} PROPERTY BUILD_RPATH ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
+    set_property(TARGET ${target}
+                 PROPERTY BUILD_RPATH ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
   endif()
 
   if(WIN32 AND "$ENV{VSCMD_VER}" STREQUAL "")

--- a/cmake/Doxygen.cmake
+++ b/cmake/Doxygen.cmake
@@ -13,16 +13,25 @@ function(Clock_enable_doxygen DOXYGEN_THEME)
   endif()
   set(DOXYGEN_CALLER_GRAPH YES)
   set(DOXYGEN_CALL_GRAPH YES)
-  set(DOXYGEN_EXTRACT_ALL YES)
+  set(DOXYGEN_EXTRACT_ALL NO)
   set(DOXYGEN_GENERATE_TREEVIEW YES)
   # svg files are much smaller than jpeg and png, and yet they have higher quality
   set(DOXYGEN_DOT_IMAGE_FORMAT svg)
   set(DOXYGEN_DOT_TRANSPARENT YES)
 
+  # set warnings
+  set(DOXYGEN_WARNINGS YES)
+  set(DOXYGEN_WARN_IF_UNDOCUMENTED YES)
+  set(DOXYGEN_WARN_IF_DOC_ERROR YES)
+  set(DOXYGEN_WARN_IF_DOCS_DISCARDED YES)
+  set(DOXYGEN_WARN_NO_PARMADOC YES)
+  set(DOXYGEN_WARN_AS_ERROR YES)
+
   # If not specified, exclude the vcpkg files and the files CMake downloads under _deps (like project_options)
   if(NOT DOXYGEN_EXCLUDE_PATTERNS)
-    set(DOXYGEN_EXCLUDE_PATTERNS "${CMAKE_CURRENT_BINARY_DIR}/vcpkg_installed/*"
-                                 "${CMAKE_CURRENT_BINARY_DIR}/_deps/*")
+    set(DOXYGEN_EXCLUDE_PATTERNS
+        "${CMAKE_CURRENT_BINARY_DIR}/vcpkg_installed/*"
+        "${CMAKE_CURRENT_BINARY_DIR}/_deps/*" "${PROJECT_SOURCE_DIR}/out/*")
   endif()
 
   if("${DOXYGEN_THEME}" STREQUAL "")

--- a/cmake/Doxygen.cmake
+++ b/cmake/Doxygen.cmake
@@ -1,7 +1,8 @@
 # Enable doxygen doc builds of source
 function(Clock_enable_doxygen DOXYGEN_THEME)
   # If not specified, use the top readme file as the first page
-  if((NOT DOXYGEN_USE_MDFILE_AS_MAINPAGE) AND EXISTS "${PROJECT_SOURCE_DIR}/README.md")
+  if((NOT DOXYGEN_USE_MDFILE_AS_MAINPAGE) AND EXISTS
+                                              "${PROJECT_SOURCE_DIR}/README.md")
     set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "${PROJECT_SOURCE_DIR}/README.md")
   endif()
 
@@ -20,25 +21,32 @@ function(Clock_enable_doxygen DOXYGEN_THEME)
 
   # If not specified, exclude the vcpkg files and the files CMake downloads under _deps (like project_options)
   if(NOT DOXYGEN_EXCLUDE_PATTERNS)
-    set(DOXYGEN_EXCLUDE_PATTERNS "${CMAKE_CURRENT_BINARY_DIR}/vcpkg_installed/*" "${CMAKE_CURRENT_BINARY_DIR}/_deps/*")
+    set(DOXYGEN_EXCLUDE_PATTERNS "${CMAKE_CURRENT_BINARY_DIR}/vcpkg_installed/*"
+                                 "${CMAKE_CURRENT_BINARY_DIR}/_deps/*")
   endif()
 
   if("${DOXYGEN_THEME}" STREQUAL "")
     set(DOXYGEN_THEME "awesome-sidebar")
   endif()
 
-  if("${DOXYGEN_THEME}" STREQUAL "awesome" OR "${DOXYGEN_THEME}" STREQUAL "awesome-sidebar")
+  if("${DOXYGEN_THEME}" STREQUAL "awesome" OR "${DOXYGEN_THEME}" STREQUAL
+                                              "awesome-sidebar")
     # use a modern doxygen theme
     # https://github.com/jothepro/doxygen-awesome-css v1.6.1
-    FetchContent_Declare(_doxygen_theme
-                         URL https://github.com/jothepro/doxygen-awesome-css/archive/refs/tags/v1.6.1.zip)
+    FetchContent_Declare(
+      _doxygen_theme
+      URL https://github.com/jothepro/doxygen-awesome-css/archive/refs/tags/v1.6.1.zip
+    )
     FetchContent_MakeAvailable(_doxygen_theme)
-    if("${DOXYGEN_THEME}" STREQUAL "awesome" OR "${DOXYGEN_THEME}" STREQUAL "awesome-sidebar")
-      set(DOXYGEN_HTML_EXTRA_STYLESHEET "${_doxygen_theme_SOURCE_DIR}/doxygen-awesome.css")
+    if("${DOXYGEN_THEME}" STREQUAL "awesome" OR "${DOXYGEN_THEME}" STREQUAL
+                                                "awesome-sidebar")
+      set(DOXYGEN_HTML_EXTRA_STYLESHEET
+          "${_doxygen_theme_SOURCE_DIR}/doxygen-awesome.css")
     endif()
     if("${DOXYGEN_THEME}" STREQUAL "awesome-sidebar")
-      set(DOXYGEN_HTML_EXTRA_STYLESHEET ${DOXYGEN_HTML_EXTRA_STYLESHEET}
-                                        "${_doxygen_theme_SOURCE_DIR}/doxygen-awesome-sidebar-only.css")
+      set(DOXYGEN_HTML_EXTRA_STYLESHEET
+          ${DOXYGEN_HTML_EXTRA_STYLESHEET}
+          "${_doxygen_theme_SOURCE_DIR}/doxygen-awesome-sidebar-only.css")
     endif()
   else()
     # use the original doxygen theme
@@ -49,6 +57,9 @@ function(Clock_enable_doxygen DOXYGEN_THEME)
 
   # add doxygen-docs target
   message(STATUS "Adding `doxygen-docs` target that builds the documentation.")
-  doxygen_add_docs(doxygen-docs ALL ${PROJECT_SOURCE_DIR}
-                   COMMENT "Generating documentation - entry file: ${CMAKE_CURRENT_BINARY_DIR}/html/index.html")
+  doxygen_add_docs(
+    doxygen-docs ALL ${PROJECT_SOURCE_DIR}
+    COMMENT
+      "Generating documentation - entry file: ${CMAKE_CURRENT_BINARY_DIR}/html/index.html"
+  )
 endfunction()

--- a/cmake/Hardening.cmake
+++ b/cmake/Hardening.cmake
@@ -9,16 +9,22 @@ macro(
   message(STATUS "** Enabling Hardening (Target ${target}) **")
 
   if(MSVC)
-    set(NEW_COMPILE_OPTIONS "${NEW_COMPILE_OPTIONS} /sdl /DYNAMICBASE /guard:cf")
-    message(STATUS "*** MSVC flags: /sdl /DYNAMICBASE /guard:cf /NXCOMPAT /CETCOMPAT")
+    set(NEW_COMPILE_OPTIONS
+        "${NEW_COMPILE_OPTIONS} /sdl /DYNAMICBASE /guard:cf")
+    message(
+      STATUS "*** MSVC flags: /sdl /DYNAMICBASE /guard:cf /NXCOMPAT /CETCOMPAT")
     set(NEW_LINK_OPTIONS "${NEW_LINK_OPTIONS} /NXCOMPAT /CETCOMPAT")
 
   elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang|GNU")
     set(NEW_CXX_DEFINITIONS "${NEW_CXX_DEFINITIONS} -D_GLIBCXX_ASSERTIONS")
     message(STATUS "*** GLIBC++ Assertions (vector[], string[], ...) enabled")
 
-    if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
-      set(NEW_COMPILE_OPTIONS "${NEW_COMPILE_OPTIONS} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3")
+    if(NOT
+       CMAKE_BUILD_TYPE
+       MATCHES
+       "Debug")
+      set(NEW_COMPILE_OPTIONS
+          "${NEW_COMPILE_OPTIONS} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3")
     endif()
     message(STATUS "*** g++/clang _FORTIFY_SOURCE=3 enabled")
 
@@ -37,7 +43,9 @@ macro(
       set(NEW_COMPILE_OPTIONS "${NEW_COMPILE_OPTIONS} -fstack-protector-strong")
       message(STATUS "*** g++/clang -fstack-protector-strong enabled")
     else()
-      message(STATUS "*** g++/clang -fstack-protector-strong NOT enabled (not supported)")
+      message(
+        STATUS
+          "*** g++/clang -fstack-protector-strong NOT enabled (not supported)")
     endif()
 
     check_cxx_compiler_flag(-fcf-protection CF_PROTECTION)
@@ -45,35 +53,52 @@ macro(
       set(NEW_COMPILE_OPTIONS "${NEW_COMPILE_OPTIONS} -fcf-protection")
       message(STATUS "*** g++/clang -fcf-protection enabled")
     else()
-      message(STATUS "*** g++/clang -fcf-protection NOT enabled (not supported)")
+      message(
+        STATUS "*** g++/clang -fcf-protection NOT enabled (not supported)")
     endif()
 
     check_cxx_compiler_flag(-fstack-clash-protection CLASH_PROTECTION)
     if(CLASH_PROTECTION)
-      if((LINUX OR CMAKE_CXX_COMPILER_ID MATCHES "GNU") AND 
-      NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16.0))
-        set(NEW_COMPILE_OPTIONS "${NEW_COMPILE_OPTIONS} -fstack-clash-protection")
+      if((LINUX OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+         AND NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+                  AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16.0))
+        set(NEW_COMPILE_OPTIONS
+            "${NEW_COMPILE_OPTIONS} -fstack-clash-protection")
         message(STATUS "*** g++/clang -fstack-clash-protection enabled")
       else()
-        message(STATUS "*** g++/clang -fstack-clash-protection NOT enabled (clang on non-Linux)")
+        message(
+          STATUS
+            "*** g++/clang -fstack-clash-protection NOT enabled (clang on non-Linux)"
+        )
       endif()
     else()
-      message(STATUS "*** g++/clang -fstack-clash-protection NOT enabled (not supported)")
+      message(
+        STATUS
+          "*** g++/clang -fstack-clash-protection NOT enabled (not supported)")
     endif()
   endif()
 
   if(${ubsan_minimal_runtime})
-    check_cxx_compiler_flag("-fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-minimal-runtime"
-                            MINIMAL_RUNTIME)
+    check_cxx_compiler_flag(
+      "-fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-minimal-runtime"
+      MINIMAL_RUNTIME)
     if(MINIMAL_RUNTIME)
-      set(NEW_COMPILE_OPTIONS "${NEW_COMPILE_OPTIONS} -fsanitize=undefined -fsanitize-minimal-runtime")
-      set(NEW_LINK_OPTIONS "${NEW_LINK_OPTIONS} -fsanitize=undefined -fsanitize-minimal-runtime")
+      set(NEW_COMPILE_OPTIONS
+          "${NEW_COMPILE_OPTIONS} -fsanitize=undefined -fsanitize-minimal-runtime"
+      )
+      set(NEW_LINK_OPTIONS
+          "${NEW_LINK_OPTIONS} -fsanitize=undefined -fsanitize-minimal-runtime")
 
       if(NOT ${global})
-        set(NEW_COMPILE_OPTIONS "${NEW_COMPILE_OPTIONS} -fno-sanitize-recover=undefined")
-        set(NEW_LINK_OPTIONS "${NEW_LINK_OPTIONS} -fno-sanitize-recover=undefined")
+        set(NEW_COMPILE_OPTIONS
+            "${NEW_COMPILE_OPTIONS} -fno-sanitize-recover=undefined")
+        set(NEW_LINK_OPTIONS
+            "${NEW_LINK_OPTIONS} -fno-sanitize-recover=undefined")
       else()
-        message(STATUS "** not enabling -fno-sanitize-recover=undefined for global consumption")
+        message(
+          STATUS
+            "** not enabling -fno-sanitize-recover=undefined for global consumption"
+        )
       endif()
 
       message(STATUS "*** ubsan minimal runtime enabled")

--- a/cmake/Linker.cmake
+++ b/cmake/Linker.cmake
@@ -4,8 +4,13 @@ macro(Clock_configure_linker project_name)
   set(USER_LINKER_OPTION
       "lld"
       CACHE STRING "Linker to be used")
-  set(USER_LINKER_OPTION_VALUES "lld" "gold" "bfd" "mold")
-  set_property(CACHE USER_LINKER_OPTION PROPERTY STRINGS ${USER_LINKER_OPTION_VALUES})
+  set(USER_LINKER_OPTION_VALUES
+      "lld"
+      "gold"
+      "bfd"
+      "mold")
+  set_property(CACHE USER_LINKER_OPTION PROPERTY STRINGS
+                                                 ${USER_LINKER_OPTION_VALUES})
   list(
     FIND
     USER_LINKER_OPTION_VALUES
@@ -15,7 +20,8 @@ macro(Clock_configure_linker project_name)
   if(${USER_LINKER_OPTION_INDEX} EQUAL -1)
     message(
       STATUS
-        "Using custom linker: '${USER_LINKER_OPTION}', explicitly supported entries are ${USER_LINKER_OPTION_VALUES}")
+        "Using custom linker: '${USER_LINKER_OPTION}', explicitly supported entries are ${USER_LINKER_OPTION_VALUES}"
+    )
   endif()
 
   if(NOT Clock_ENABLE_USER_LINKER)

--- a/cmake/PackageProject.cmake
+++ b/cmake/PackageProject.cmake
@@ -40,12 +40,16 @@ function(Clock_package_project)
     "${ARGN}")
 
   # Set default options
-  include(GNUInstallDirs) # Define GNU standard installation directories such as CMAKE_INSTALL_DATADIR
+  include(GNUInstallDirs
+  )# Define GNU standard installation directories such as CMAKE_INSTALL_DATADIR
 
   # set default packaged targets
   if(NOT _PackageProject_TARGETS)
     get_all_installable_targets(_PackageProject_TARGETS)
-    message(STATUS "package_project: considering ${_PackageProject_TARGETS} as the exported targets")
+    message(
+      STATUS
+        "package_project: considering ${_PackageProject_TARGETS} as the exported targets"
+    )
   endif()
 
   # default to the name of the project or the given name
@@ -71,14 +75,17 @@ function(Clock_package_project)
   if("${_PackageProject_CONFIG_EXPORT_DESTINATION}" STREQUAL "")
     set(_PackageProject_CONFIG_EXPORT_DESTINATION "${CMAKE_BINARY_DIR}")
   endif()
-  set(_PackageProject_EXPORT_DESTINATION "${_PackageProject_CONFIG_EXPORT_DESTINATION}")
+  set(_PackageProject_EXPORT_DESTINATION
+      "${_PackageProject_CONFIG_EXPORT_DESTINATION}")
 
   # use datadir (works better with vcpkg, etc)
   if("${_PackageProject_CONFIG_INSTALL_DESTINATION}" STREQUAL "")
-    set(_PackageProject_CONFIG_INSTALL_DESTINATION "${CMAKE_INSTALL_DATADIR}/${_PackageProject_NAME}")
+    set(_PackageProject_CONFIG_INSTALL_DESTINATION
+        "${CMAKE_INSTALL_DATADIR}/${_PackageProject_NAME}")
   endif()
   # ycm args
-  set(_PackageProject_INSTALL_DESTINATION "${_PackageProject_CONFIG_INSTALL_DESTINATION}")
+  set(_PackageProject_INSTALL_DESTINATION
+      "${_PackageProject_CONFIG_INSTALL_DESTINATION}")
 
   # Installation of the public/interface includes
   if(NOT
@@ -110,7 +117,8 @@ function(Clock_package_project)
       list(APPEND _PUBLIC_DEPENDENCIES_CONFIG "${DEP} CONFIG")
     endforeach()
   endif()
-  list(APPEND _PackageProject_PUBLIC_DEPENDENCIES ${_PUBLIC_DEPENDENCIES_CONFIG})
+  list(APPEND _PackageProject_PUBLIC_DEPENDENCIES
+       ${_PUBLIC_DEPENDENCIES_CONFIG})
   # ycm arg
   set(_PackageProject_DEPENDENCIES ${_PackageProject_PUBLIC_DEPENDENCIES})
 
@@ -125,7 +133,8 @@ function(Clock_package_project)
     endforeach()
   endif()
   # ycm arg
-  list(APPEND _PackageProject_PRIVATE_DEPENDENCIES ${_PRIVATE_DEPENDENCIES_CONFIG})
+  list(APPEND _PackageProject_PRIVATE_DEPENDENCIES
+       ${_PRIVATE_DEPENDENCIES_CONFIG})
 
   # Installation of package (compatible with vcpkg, etc)
   install(
@@ -134,7 +143,9 @@ function(Clock_package_project)
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shlib
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
-    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${_PackageProject_NAME}" COMPONENT dev)
+    PUBLIC_HEADER
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${_PackageProject_NAME}"
+      COMPONENT dev)
 
   # install the usage file
   set(_targets_str "")
@@ -148,16 +159,18 @@ function(Clock_package_project)
     target_link_libraries(main PRIVATE ${_targets_str})
   ")
   install(CODE "MESSAGE(STATUS \"${USAGE_FILE_CONTENT}\")")
-  file(WRITE "${_PackageProject_EXPORT_DESTINATION}/usage" "${USAGE_FILE_CONTENT}")
+  file(WRITE "${_PackageProject_EXPORT_DESTINATION}/usage"
+       "${USAGE_FILE_CONTENT}")
   install(FILES "${_PackageProject_EXPORT_DESTINATION}/usage"
           DESTINATION "${_PackageProject_CONFIG_INSTALL_DESTINATION}")
 
   unset(_PackageProject_TARGETS)
 
   # download ForwardArguments
-  FetchContent_Populate (
+  FetchContent_Populate(
     _fargs
-    URL https://github.com/polysquare/cmake-forward-arguments/archive/8c50d1f956172edb34e95efa52a2d5cb1f686ed2.zip)
+    URL https://github.com/polysquare/cmake-forward-arguments/archive/8c50d1f956172edb34e95efa52a2d5cb1f686ed2.zip
+  )
 
   FetchContent_GetProperties(_fargs)
 
@@ -176,7 +189,8 @@ function(Clock_package_project)
     "${_multiValueArgs};DEPENDENCIES;PRIVATE_DEPENDENCIES")
 
   # download ycm
-  FetchContent_Populate(_ycm URL https://github.com/robotology/ycm/archive/refs/tags/v0.13.0.zip)
+  FetchContent_Populate(
+    _ycm URL https://github.com/robotology/ycm/archive/refs/tags/v0.13.0.zip)
   FetchContent_GetProperties(_ycm)
   include("${_ycm_SOURCE_DIR}/modules/InstallBasicPackageFiles.cmake")
 

--- a/cmake/PreventInSourceBuilds.cmake
+++ b/cmake/PreventInSourceBuilds.cmake
@@ -16,4 +16,4 @@ function(Clock_assure_out_of_source_builds)
   endif()
 endfunction()
 
-Clock_assure_out_of_source_builds()
+clock_assure_out_of_source_builds()

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -7,7 +7,8 @@ function(
   ENABLE_SANITIZER_THREAD
   ENABLE_SANITIZER_MEMORY)
 
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES
+                                             ".*Clang")
     set(SANITIZERS "")
 
     if(${ENABLE_SANITIZER_ADDRESS})
@@ -24,7 +25,10 @@ function(
 
     if(${ENABLE_SANITIZER_THREAD})
       if("address" IN_LIST SANITIZERS OR "leak" IN_LIST SANITIZERS)
-        message(WARNING "Thread sanitizer does not work with Address and Leak sanitizer enabled")
+        message(
+          WARNING
+            "Thread sanitizer does not work with Address and Leak sanitizer enabled"
+        )
       else()
         list(APPEND SANITIZERS "thread")
       endif()
@@ -38,7 +42,10 @@ function(
       if("address" IN_LIST SANITIZERS
          OR "thread" IN_LIST SANITIZERS
          OR "leak" IN_LIST SANITIZERS)
-        message(WARNING "Memory sanitizer does not work with Address, Thread or Leak sanitizer enabled")
+        message(
+          WARNING
+            "Memory sanitizer does not work with Address, Thread or Leak sanitizer enabled"
+        )
       else()
         list(APPEND SANITIZERS "memory")
       endif()
@@ -67,8 +74,10 @@ function(
        STREQUAL
        "")
       if(NOT MSVC)
-        target_compile_options(${project_name} INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
-        target_link_options(${project_name} INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
+        target_compile_options(${project_name}
+                               INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
+        target_link_options(${project_name} INTERFACE
+                            -fsanitize=${LIST_OF_SANITIZERS})
       else()
         string(FIND "$ENV{PATH}" "$ENV{VSINSTALLDIR}" index_of_vs_install_dir)
         if("${index_of_vs_install_dir}" STREQUAL "-1")
@@ -77,14 +86,15 @@ function(
               "Using MSVC sanitizers requires setting the MSVC environment before building the project. Please manually open the MSVC command prompt and rebuild the project."
           )
         endif()
-        target_compile_options(${project_name} INTERFACE /fsanitize=${LIST_OF_SANITIZERS} /Zi /INCREMENTAL:NO)
-        target_compile_definitions(${project_name} INTERFACE _DISABLE_VECTOR_ANNOTATION _DISABLE_STRING_ANNOTATION)
+        target_compile_options(
+          ${project_name} INTERFACE /fsanitize=${LIST_OF_SANITIZERS} /Zi
+                                    /INCREMENTAL:NO)
+        target_compile_definitions(
+          ${project_name} INTERFACE _DISABLE_VECTOR_ANNOTATION
+                                    _DISABLE_STRING_ANNOTATION)
         target_link_options(${project_name} INTERFACE /INCREMENTAL:NO)
       endif()
     endif()
   endif()
 
 endfunction()
-
-
-

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -1,6 +1,7 @@
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
+  message(
+    STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
   set(CMAKE_BUILD_TYPE
       RelWithDebInfo
       CACHE STRING "Choose the type of build." FORCE)
@@ -21,7 +22,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
   if(WIN32)
     # On Windows cuda nvcc uses cl and not clang
-    add_compile_options($<$<COMPILE_LANGUAGE:C>:-fcolor-diagnostics> $<$<COMPILE_LANGUAGE:CXX>:-fcolor-diagnostics>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C>:-fcolor-diagnostics>
+                        $<$<COMPILE_LANGUAGE:CXX>:-fcolor-diagnostics>)
   else()
     add_compile_options(-fcolor-diagnostics)
   endif()
@@ -36,9 +38,11 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND MSVC_VERSION GREATER 1900)
   add_compile_options(/diagnostics:column)
 else()
-  message(STATUS "No colored compiler diagnostic set for '${CMAKE_CXX_COMPILER_ID}' compiler.")
+  message(
+    STATUS
+      "No colored compiler diagnostic set for '${CMAKE_CXX_COMPILER_ID}' compiler."
+  )
 endif()
-
 
 # run vcvarsall when msvc is used
 include("${CMAKE_CURRENT_LIST_DIR}/VCEnvironment.cmake")

--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -34,14 +34,16 @@ macro(Clock_enable_cppcheck WARNINGS_AS_ERRORS CPPCHECK_OPTIONS)
           --suppress=${SUPPRESS_DIR})
     else()
       # if the user provides a CPPCHECK_OPTIONS with a template specified, it will override this template
-      set(CMAKE_CXX_CPPCHECK ${CPPCHECK} --template=${CPPCHECK_TEMPLATE} ${CPPCHECK_OPTIONS})
+      set(CMAKE_CXX_CPPCHECK ${CPPCHECK} --template=${CPPCHECK_TEMPLATE}
+                             ${CPPCHECK_OPTIONS})
     endif()
 
     if(NOT
        "${CMAKE_CXX_STANDARD}"
        STREQUAL
        "")
-      set(CMAKE_CXX_CPPCHECK ${CMAKE_CXX_CPPCHECK} --std=c++${CMAKE_CXX_STANDARD})
+      set(CMAKE_CXX_CPPCHECK ${CMAKE_CXX_CPPCHECK}
+                             --std=c++${CMAKE_CXX_STANDARD})
     endif()
     if(${WARNINGS_AS_ERRORS})
       list(APPEND CMAKE_CXX_CPPCHECK --error-exitcode=2)
@@ -69,7 +71,8 @@ macro(Clock_enable_clang_tidy target WARNINGS_AS_ERRORS)
       if(NOT ("${TARGET_PCH}" STREQUAL "TARGET_PCH-NOTFOUND"))
         message(
           SEND_ERROR
-            "clang-tidy cannot be enabled with non-clang compiler and PCH, clang-tidy fails to handle gcc's PCH file")
+            "clang-tidy cannot be enabled with non-clang compiler and PCH, clang-tidy fails to handle gcc's PCH file"
+        )
       endif()
     endif()
 
@@ -86,9 +89,11 @@ macro(Clock_enable_clang_tidy target WARNINGS_AS_ERRORS)
        STREQUAL
        "")
       if("${CLANG_TIDY_OPTIONS_DRIVER_MODE}" STREQUAL "cl")
-        set(CLANG_TIDY_OPTIONS ${CLANG_TIDY_OPTIONS} -extra-arg=/std:c++${CMAKE_CXX_STANDARD})
+        set(CLANG_TIDY_OPTIONS ${CLANG_TIDY_OPTIONS}
+                               -extra-arg=/std:c++${CMAKE_CXX_STANDARD})
       else()
-        set(CLANG_TIDY_OPTIONS ${CLANG_TIDY_OPTIONS} -extra-arg=-std=c++${CMAKE_CXX_STANDARD})
+        set(CLANG_TIDY_OPTIONS ${CLANG_TIDY_OPTIONS}
+                               -extra-arg=-std=c++${CMAKE_CXX_STANDARD})
       endif()
     endif()
 
@@ -109,6 +114,7 @@ macro(Clock_enable_include_what_you_use)
   if(INCLUDE_WHAT_YOU_USE)
     set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${INCLUDE_WHAT_YOU_USE})
   else()
-    message(${WARNING_MESSAGE} "include-what-you-use requested but executable not found")
+    message(${WARNING_MESSAGE}
+            "include-what-you-use requested but executable not found")
   endif()
 endmacro()

--- a/cmake/SystemLink.cmake
+++ b/cmake/SystemLink.cmake
@@ -47,7 +47,10 @@ function(
     if(lib_include_dirs)
       target_include_system_directories(${target} ${scope} ${lib_include_dirs})
     else()
-      message(TRACE "${lib} library does not have the INTERFACE_INCLUDE_DIRECTORIES property.")
+      message(
+        TRACE
+        "${lib} library does not have the INTERFACE_INCLUDE_DIRECTORIES property."
+      )
     endif()
   endif()
 endfunction()

--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -1,5 +1,6 @@
 function(Clock_enable_coverage project_name)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES
+                                             ".*Clang")
     target_compile_options(${project_name} INTERFACE --coverage -O0 -g)
     target_link_libraries(${project_name} INTERFACE --coverage)
   endif()

--- a/cmake/VCEnvironment.cmake
+++ b/cmake/VCEnvironment.cmake
@@ -3,7 +3,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/Utilities.cmake")
 macro(detect_architecture)
   # detect the architecture
   string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" CMAKE_SYSTEM_PROCESSOR_LOWER)
-  if(CMAKE_SYSTEM_PROCESSOR_LOWER STREQUAL x86 OR CMAKE_SYSTEM_PROCESSOR_LOWER MATCHES "^i[3456]86$")
+  if(CMAKE_SYSTEM_PROCESSOR_LOWER STREQUAL x86 OR CMAKE_SYSTEM_PROCESSOR_LOWER
+                                                  MATCHES "^i[3456]86$")
     set(VCVARSALL_ARCH x86)
   elseif(
     CMAKE_SYSTEM_PROCESSOR_LOWER STREQUAL x64
@@ -12,14 +13,18 @@ macro(detect_architecture)
     set(VCVARSALL_ARCH x64)
   elseif(CMAKE_SYSTEM_PROCESSOR_LOWER STREQUAL arm)
     set(VCVARSALL_ARCH arm)
-  elseif(CMAKE_SYSTEM_PROCESSOR_LOWER STREQUAL arm64 OR CMAKE_SYSTEM_PROCESSOR_LOWER STREQUAL aarch64)
+  elseif(CMAKE_SYSTEM_PROCESSOR_LOWER STREQUAL arm64
+         OR CMAKE_SYSTEM_PROCESSOR_LOWER STREQUAL aarch64)
     set(VCVARSALL_ARCH arm64)
   else()
     if(CMAKE_HOST_SYSTEM_PROCESSOR)
       set(VCVARSALL_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
     else()
       set(VCVARSALL_ARCH x64)
-      message(STATUS "Unknown architecture CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR_LOWER} - using x64")
+      message(
+        STATUS
+          "Unknown architecture CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR_LOWER} - using x64"
+      )
     endif()
   endif()
 endmacro()
@@ -46,7 +51,10 @@ function(run_vcvarsall)
       detect_architecture()
 
       # run vcvarsall and print the environment variables
-      message(STATUS "Running `${VCVARSALL_FILE} ${VCVARSALL_ARCH}` to set up the MSVC environment")
+      message(
+        STATUS
+          "Running `${VCVARSALL_FILE} ${VCVARSALL_ARCH}` to set up the MSVC environment"
+      )
       execute_process(
         COMMAND
           "cmd" "/c" ${VCVARSALL_FILE} ${VCVARSALL_ARCH} #
@@ -56,7 +64,8 @@ function(run_vcvarsall)
         OUTPUT_STRIP_TRAILING_WHITESPACE)
 
       # parse the output and get the environment variables string
-      find_substring_by_prefix(VCVARSALL_ENV "VCVARSALL_ENV_START" "${VCVARSALL_OUTPUT}")
+      find_substring_by_prefix(VCVARSALL_ENV "VCVARSALL_ENV_START"
+                               "${VCVARSALL_OUTPUT}")
 
       # set the environment variables
       set_env_from_string("${VCVARSALL_ENV}")

--- a/configured_files/CMakeLists.txt
+++ b/configured_files/CMakeLists.txt
@@ -1,7 +1,7 @@
-
 # A very simple example of a configured file that might need to be
 # converted to one that is publicly installed in the case that
 # you are developing a library
-configure_file("config.hpp.in" "${CMAKE_BINARY_DIR}/configured_files/include/internal_use_only/config.hpp" ESCAPE_QUOTES)
-
-
+configure_file(
+  "config.hpp.in"
+  "${CMAKE_BINARY_DIR}/configured_files/include/internal_use_only/config.hpp"
+  ESCAPE_QUOTES)

--- a/configured_files/config.hpp.in
+++ b/configured_files/config.hpp.in
@@ -2,14 +2,17 @@
 #define Clock_CONFIG_HPP
 
 // this is a basic example of how a CMake configured file might look
-// in this particular case, we are using it to set the version number of our executable
+// in this particular case, we are using it to set the version number of our
+// executable
 namespace Clock::cmake {
 inline constexpr std::string_view project_name = "@PROJECT_NAME@";
 inline constexpr std::string_view project_version = "@PROJECT_VERSION@";
+// clang-format off
 inline constexpr int project_version_major { @PROJECT_VERSION_MAJOR@ };
 inline constexpr int project_version_minor { @PROJECT_VERSION_MINOR@ };
 inline constexpr int project_version_patch { @PROJECT_VERSION_PATCH@ };
 inline constexpr int project_version_tweak { @PROJECT_VERSION_TWEAK@ };
+// clang-format on
 inline constexpr std::string_view git_sha = "@GIT_SHA@";
 }// namespace Clock::cmake
 

--- a/fuzz_test/CMakeLists.txt
+++ b/fuzz_test/CMakeLists.txt
@@ -16,6 +16,8 @@ target_compile_options(fuzz_tester PRIVATE -fsanitize=fuzzer)
 # Allow short runs during automated testing to see if something new breaks
 set(FUZZ_RUNTIME
     10
-    CACHE STRING "Number of seconds to run fuzz tests during ctest run") # Default of 10 seconds
+    CACHE STRING "Number of seconds to run fuzz tests during ctest run"
+)# Default of 10 seconds
 
-add_test(NAME fuzz_tester_run COMMAND fuzz_tester -max_total_time=${FUZZ_RUNTIME})
+add_test(NAME fuzz_tester_run COMMAND fuzz_tester
+                                      -max_total_time=${FUZZ_RUNTIME})

--- a/fuzz_test/fuzz_tester.cpp
+++ b/fuzz_test/fuzz_tester.cpp
@@ -3,21 +3,22 @@
 #include <fmt/base.h>
 #include <iterator>
 
-[[nodiscard]] auto sum_values(const uint8_t *Data, size_t Size)
+[[nodiscard]] auto sumValues(const uint8_t *data, size_t size)
 {
-  constexpr auto scale = 1000;
+  constexpr auto SCALE = 1000;
 
   int value = 0;
-  for (std::size_t offset = 0; offset < Size; ++offset) {
-    value += static_cast<int>(*std::next(Data, static_cast<long>(offset))) * scale;
+  for (std::size_t offset = 0; offset < size; ++offset) {
+    value +=
+      static_cast<int>(*std::next(data, static_cast<long>(offset))) * SCALE;
   }
   return value;
 }
 
 // Fuzzer that attempts to invoke undefined behavior for signed integer overflow
 // cppcheck-suppress unusedFunction symbolName=LLVMFuzzerTestOneInput
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
+extern "C" int llvmFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
-  fmt::print("Value sum: {}, len{}\n", sum_values(Data, Size), Size);
+  fmt::print("Value sum: {}, len{}\n", sumValues(Data, Size), Size);
   return 0;
 }

--- a/src/ftxui_sample/CMakeLists.txt
+++ b/src/ftxui_sample/CMakeLists.txt
@@ -1,19 +1,17 @@
 add_executable(intro main.cpp)
 
-target_link_libraries(
-  intro
-  PRIVATE Clock::Clock_options
-          Clock::Clock_warnings)
+target_link_libraries(intro PRIVATE Clock::Clock_options Clock::Clock_warnings)
 
 target_link_system_libraries(
   intro
   PRIVATE
-          CLI11::CLI11
-          fmt::fmt
-          spdlog::spdlog
-          lefticus::tools
-          ftxui::screen
-          ftxui::dom
-          ftxui::component)
+  CLI11::CLI11
+  fmt::fmt
+  spdlog::spdlog
+  lefticus::tools
+  ftxui::screen
+  ftxui::dom
+  ftxui::component)
 
-target_include_directories(intro PRIVATE "${CMAKE_BINARY_DIR}/configured_files/include")
+target_include_directories(
+  intro PRIVATE "${CMAKE_BINARY_DIR}/configured_files/include")

--- a/src/ftxui_sample/main.cpp
+++ b/src/ftxui_sample/main.cpp
@@ -32,22 +32,55 @@
 #include <vector>
 
 
+/**
+ * Game board representation.
+ */
 template<std::size_t Width, std::size_t Height> struct GameBoard
 {
+  /**
+   * The width of the game board.
+   */
   static constexpr std::size_t WIDTH = Width;
+  /**
+   * The height of the game board.
+   */
   static constexpr std::size_t HEIGHT = Height;
 
+  /**
+   * The game board is represented as a 2D array of strings and values.
+   * The strings are used to display the state of each cell, and the values
+   * are used to store the actual state of each cell.
+   */
   std::array<std::array<std::string, HEIGHT>, WIDTH> strings;
+
+  /**
+   * The values are used to store the actual state of each cell.
+   */
   std::array<std::array<bool, HEIGHT>, WIDTH> values{};
 
+  /**
+   * The number of moves made in the game.
+   */
   std::size_t move_count{ 0 };
 
+  /**
+   * Accessor for the string at the given coordinates.
+   * @param cur_x The x-coordinate of the string.
+   * @param cur_y The y-coordinate of the string.
+   */
   std::string &getString(std::size_t cur_x, std::size_t cur_y)
   {
     return strings.at(cur_x).at(cur_y);
   }
 
 
+  /**
+   * Sets the value at the given coordinates and updates the string
+   * representation.
+   * @param cur_x The x-coordinate of the value.
+   * @param cur_y The y-coordinate of the value.
+   * @param new_value The new value to set.
+   */
   void set(std::size_t cur_x, std::size_t cur_y, bool new_value)
   {
     get(cur_x, cur_y) = new_value;
@@ -59,6 +92,10 @@ template<std::size_t Width, std::size_t Height> struct GameBoard
     }
   }
 
+  /**
+   * Visits each cell in the game board and applies the given visitor function.
+   * @param visitor The function to apply to each cell.
+   */
   void visit(auto visitor)
   {
     for (std::size_t cur_x = 0; cur_x < WIDTH; ++cur_x) {
@@ -68,11 +105,23 @@ template<std::size_t Width, std::size_t Height> struct GameBoard
     }
   }
 
+  /**
+   * Accessor for the value at the given coordinates.
+   * @param cur_x The x-coordinate of the value.
+   * @param cur_y The y-coordinate of the value.
+   * @return A reference to the value at the given coordinates.
+   */
   [[nodiscard]] bool get(std::size_t cur_x, std::size_t cur_y) const
   {
     return values.at(cur_x).at(cur_y);
   }
 
+  /**
+   * Accessor for the value at the given coordinates.
+   * @param cur_x The x-coordinate of the value.
+   * @param cur_y The y-coordinate of the value.
+   * @return A reference to the value at the given coordinates.
+   */
   [[nodiscard]] bool &get(std::size_t cur_x, std::size_t cur_y)
   {
     return values.at(cur_x).at(cur_y);
@@ -85,6 +134,9 @@ template<std::size_t Width, std::size_t Height> struct GameBoard
     });
   }
 
+  /**
+   * Updates the string representation of the game board.
+   */
   void updateStrings()
   {
     for (std::size_t cur_x = 0; cur_x < WIDTH; ++cur_x) {
@@ -94,11 +146,23 @@ template<std::size_t Width, std::size_t Height> struct GameBoard
     }
   }
 
+  /**
+   * Toggles the value at the given coordinates and updates the surrounding
+   * values.
+   * @param cur_x The x-coordinate of the value.
+   * @param cur_y The y-coordinate of the value.
+   */
   void toggle(std::size_t cur_x, std::size_t cur_y)
   {
     set(cur_x, cur_y, !get(cur_x, cur_y));
   }
 
+  /**
+   * Presses the button at the given coordinates and toggles the surrounding
+   * values.
+   * @param cur_x The x-coordinate of the button.
+   * @param cur_y The y-coordinate of the button.
+   */
   void press(std::size_t cur_x, std::size_t cur_y)
   {
     ++move_count;
@@ -109,6 +173,10 @@ template<std::size_t Width, std::size_t Height> struct GameBoard
     if (cur_y < HEIGHT - 1) { toggle(cur_x, cur_y + 1); }
   }
 
+  /**
+   * Checks if the game board is solved.
+   * @return True if all values are true, false otherwise.
+   */
   [[nodiscard]] bool solved() const
   {
     for (std::size_t cur_x = 0; cur_x < WIDTH; ++cur_x) {
@@ -201,32 +269,64 @@ void consequenceGame()
 }
 }// namespace
 
+/**
+ * RGB color representation.
+ */
 struct Color
 {
+  /// Represents the red component of the color.
   lefticus::tools::uint_np8_t r{ static_cast<std::uint8_t>(0) };
+  /// Represents the green component of the color.
   lefticus::tools::uint_np8_t g{ static_cast<std::uint8_t>(0) };
+  /// Represents the blue component of the color.
   lefticus::tools::uint_np8_t b{ static_cast<std::uint8_t>(0) };
 };
 
 // A simple way of representing a bitmap on screen using only characters
+/**
+ * This is a custom Node that can be used to render a bitmap on the screen.
+ */
 struct Bitmap : ftxui::Node
 {
+  /**
+   * Constructor for Bitmap.
+   *
+   * @param width The width of the bitmap.
+   * @param height The height of the bitmap.
+   */
   Bitmap(std::size_t width,// NOLINT
     std::size_t height)// NOLINT same typed parameters adjacent to each other
     : width_(width), height_(height)
   {}
 
+  /**
+   * Accessor for the pixel at the given coordinates.
+   *
+   * @param cur_x The x-coordinate of the pixel.
+   * @param cur_y The y-coordinate of the pixel.
+   * @return A reference to the pixel at the given coordinates.
+   */
   Color &at(std::size_t cur_x, std::size_t cur_y)
   {
     return pixels_.at((width_ * cur_y) + cur_x);
   }
 
+  /**
+   * Computes the requirement for the bitmap.
+   * This is used to determine how much space the bitmap needs on the screen.
+   * It sets the minimum width and height of the bitmap.
+   */
   void ComputeRequirement() override
   {
     requirement_.min_x = static_cast<int>(width_);
     requirement_.min_y = static_cast<int>(height_ / 2);
   }
 
+  /**
+   * Renders the bitmap on the given screen.
+   *
+   * @param screen The screen to render the bitmap on.
+   */
   void Render(ftxui::Screen &screen) override
   {
     for (std::size_t cur_x = 0; cur_x < width_; ++cur_x) {
@@ -246,10 +346,32 @@ struct Bitmap : ftxui::Node
     }
   }
 
+  /**
+   * Accessor for the width of the bitmap.
+   *
+   * @return The width of the bitmap.
+   */
   [[nodiscard]] auto width() const noexcept { return width_; }
 
+  /**
+   * Accessor for the height of the bitmap.
+   *
+   * @return The height of the bitmap.
+   */
   [[nodiscard]] auto height() const noexcept { return height_; }
 
+  /**
+   * Accessor for the pixel data of the bitmap.
+   *
+   * @return A reference to the pixel data.
+   */
+  [[nodiscard]] const auto &data() const noexcept { return pixels_; }
+
+  /**
+   * Accessor for the pixel data of the bitmap.
+   *
+   * @return A reference to the pixel data.
+   */
   [[nodiscard]] auto &data() noexcept { return pixels_; }
 
 private:

--- a/src/ftxui_sample/main.cpp
+++ b/src/ftxui_sample/main.cpp
@@ -34,15 +34,18 @@
 
 template<std::size_t Width, std::size_t Height> struct GameBoard
 {
-  static constexpr std::size_t width = Width;
-  static constexpr std::size_t height = Height;
+  static constexpr std::size_t WIDTH = Width;
+  static constexpr std::size_t HEIGHT = Height;
 
-  std::array<std::array<std::string, height>, width> strings;
-  std::array<std::array<bool, height>, width> values{};
+  std::array<std::array<std::string, HEIGHT>, WIDTH> strings;
+  std::array<std::array<bool, HEIGHT>, WIDTH> values{};
 
   std::size_t move_count{ 0 };
 
-  std::string &get_string(std::size_t cur_x, std::size_t cur_y) { return strings.at(cur_x).at(cur_y); }
+  std::string &getString(std::size_t cur_x, std::size_t cur_y)
+  {
+    return strings.at(cur_x).at(cur_y);
+  }
 
 
   void set(std::size_t cur_x, std::size_t cur_y, bool new_value)
@@ -50,36 +53,51 @@ template<std::size_t Width, std::size_t Height> struct GameBoard
     get(cur_x, cur_y) = new_value;
 
     if (new_value) {
-      get_string(cur_x, cur_y) = " ON";
+      getString(cur_x, cur_y) = " ON";
     } else {
-      get_string(cur_x, cur_y) = "OFF";
+      getString(cur_x, cur_y) = "OFF";
     }
   }
 
   void visit(auto visitor)
   {
-    for (std::size_t cur_x = 0; cur_x < width; ++cur_x) {
-      for (std::size_t cur_y = 0; cur_y < height; ++cur_y) { visitor(cur_x, cur_y, *this); }
+    for (std::size_t cur_x = 0; cur_x < WIDTH; ++cur_x) {
+      for (std::size_t cur_y = 0; cur_y < HEIGHT; ++cur_y) {
+        visitor(cur_x, cur_y, *this);
+      }
     }
   }
 
-  [[nodiscard]] bool get(std::size_t cur_x, std::size_t cur_y) const { return values.at(cur_x).at(cur_y); }
+  [[nodiscard]] bool get(std::size_t cur_x, std::size_t cur_y) const
+  {
+    return values.at(cur_x).at(cur_y);
+  }
 
-  [[nodiscard]] bool &get(std::size_t cur_x, std::size_t cur_y) { return values.at(cur_x).at(cur_y); }
+  [[nodiscard]] bool &get(std::size_t cur_x, std::size_t cur_y)
+  {
+    return values.at(cur_x).at(cur_y);
+  }
 
   GameBoard()
   {
-    visit([](const auto cur_x, const auto cur_y, auto &gameboard) { gameboard.set(cur_x, cur_y, true); });
+    visit([](const auto cur_x, const auto cur_y, auto &gameboard) {
+      gameboard.set(cur_x, cur_y, true);
+    });
   }
 
-  void update_strings()
+  void updateStrings()
   {
-    for (std::size_t cur_x = 0; cur_x < width; ++cur_x) {
-      for (std::size_t cur_y = 0; cur_y < height; ++cur_y) { set(cur_x, cur_y, get(cur_x, cur_y)); }
+    for (std::size_t cur_x = 0; cur_x < WIDTH; ++cur_x) {
+      for (std::size_t cur_y = 0; cur_y < HEIGHT; ++cur_y) {
+        set(cur_x, cur_y, get(cur_x, cur_y));
+      }
     }
   }
 
-  void toggle(std::size_t cur_x, std::size_t cur_y) { set(cur_x, cur_y, !get(cur_x, cur_y)); }
+  void toggle(std::size_t cur_x, std::size_t cur_y)
+  {
+    set(cur_x, cur_y, !get(cur_x, cur_y));
+  }
 
   void press(std::size_t cur_x, std::size_t cur_y)
   {
@@ -87,14 +105,14 @@ template<std::size_t Width, std::size_t Height> struct GameBoard
     toggle(cur_x, cur_y);
     if (cur_x > 0) { toggle(cur_x - 1, cur_y); }
     if (cur_y > 0) { toggle(cur_x, cur_y - 1); }
-    if (cur_x < width - 1) { toggle(cur_x + 1, cur_y); }
-    if (cur_y < height - 1) { toggle(cur_x, cur_y + 1); }
+    if (cur_x < WIDTH - 1) { toggle(cur_x + 1, cur_y); }
+    if (cur_y < HEIGHT - 1) { toggle(cur_x, cur_y + 1); }
   }
 
   [[nodiscard]] bool solved() const
   {
-    for (std::size_t cur_x = 0; cur_x < width; ++cur_x) {
-      for (std::size_t cur_y = 0; cur_y < height; ++cur_y) {
+    for (std::size_t cur_x = 0; cur_x < WIDTH; ++cur_x) {
+      for (std::size_t cur_y = 0; cur_y < HEIGHT; ++cur_y) {
         if (!get(cur_x, cur_y)) { return false; }
       }
     }
@@ -104,7 +122,7 @@ template<std::size_t Width, std::size_t Height> struct GameBoard
 };
 
 namespace {
-void consequence_game()
+void consequenceGame()
 {
   auto screen = ftxui::ScreenInteractive::TerminalOutput();
 
@@ -119,12 +137,13 @@ void consequence_game()
 
   const auto make_buttons = [&] {
     std::vector<ftxui::Component> buttons;
-    for (std::size_t cur_x = 0; cur_x < game_board.width; ++cur_x) {
-      for (std::size_t cur_y = 0; cur_y < game_board.height; ++cur_y) {
-        buttons.push_back(ftxui::Button(&game_board.get_string(cur_x, cur_y), [=, &game_board] {
-          if (!game_board.solved()) { game_board.press(cur_x, cur_y); }
-          update_quit_text(game_board);
-        }));
+    for (std::size_t cur_x = 0; cur_x < game_board.WIDTH; ++cur_x) {
+      for (std::size_t cur_y = 0; cur_y < game_board.HEIGHT; ++cur_y) {
+        buttons.push_back(
+          ftxui::Button(&game_board.getString(cur_x, cur_y), [=, &game_board] {
+            if (!game_board.solved()) { game_board.press(cur_x, cur_y); }
+            update_quit_text(game_board);
+          }));
       }
     }
     return buttons;
@@ -139,9 +158,9 @@ void consequence_game()
 
     std::size_t idx = 0;
 
-    for (std::size_t cur_x = 0; cur_x < game_board.width; ++cur_x) {
+    for (std::size_t cur_x = 0; cur_x < game_board.WIDTH; ++cur_x) {
       std::vector<ftxui::Element> row;
-      for (std::size_t cur_y = 0; cur_y < game_board.height; ++cur_y) {
+      for (std::size_t cur_y = 0; cur_y < game_board.HEIGHT; ++cur_y) {
         row.push_back(buttons[idx]->Render());
         ++idx;
       }
@@ -154,17 +173,21 @@ void consequence_game()
   };
 
 
-  static constexpr int randomization_iterations = 100;
-  static constexpr int random_seed = 42;
+  static constexpr int RANDOMIZATION_ITERATIONS = 100;
+  static constexpr int RANDOM_SEED = 42;
 
-  std::mt19937 gen32{ random_seed };// NOLINT fixed seed
+  std::mt19937 gen32{ RANDOM_SEED };// NOLINT fixed seed
 
   // NOLINTNEXTLINE This cannot be const
-  std::uniform_int_distribution<std::size_t> cur_x(static_cast<std::size_t>(0), game_board.width - 1);
+  std::uniform_int_distribution<std::size_t> cur_x(
+    static_cast<std::size_t>(0), game_board.WIDTH - 1);
   // NOLINTNEXTLINE This cannot be const
-  std::uniform_int_distribution<std::size_t> cur_y(static_cast<std::size_t>(0), game_board.height - 1);
+  std::uniform_int_distribution<std::size_t> cur_y(
+    static_cast<std::size_t>(0), game_board.HEIGHT - 1);
 
-  for (int i = 0; i < randomization_iterations; ++i) { game_board.press(cur_x(gen32), cur_y(gen32)); }
+  for (int i = 0; i < RANDOMIZATION_ITERATIONS; ++i) {
+    game_board.press(cur_x(gen32), cur_y(gen32));
+  }
   game_board.move_count = 0;
   update_quit_text(game_board);
 
@@ -180,19 +203,23 @@ void consequence_game()
 
 struct Color
 {
-  lefticus::tools::uint_np8_t R{ static_cast<std::uint8_t>(0) };
-  lefticus::tools::uint_np8_t G{ static_cast<std::uint8_t>(0) };
-  lefticus::tools::uint_np8_t B{ static_cast<std::uint8_t>(0) };
+  lefticus::tools::uint_np8_t r{ static_cast<std::uint8_t>(0) };
+  lefticus::tools::uint_np8_t g{ static_cast<std::uint8_t>(0) };
+  lefticus::tools::uint_np8_t b{ static_cast<std::uint8_t>(0) };
 };
 
 // A simple way of representing a bitmap on screen using only characters
 struct Bitmap : ftxui::Node
 {
-  Bitmap(std::size_t width, std::size_t height)// NOLINT same typed parameters adjacent to each other
+  Bitmap(std::size_t width,// NOLINT
+    std::size_t height)// NOLINT same typed parameters adjacent to each other
     : width_(width), height_(height)
   {}
 
-  Color &at(std::size_t cur_x, std::size_t cur_y) { return pixels.at((width_ * cur_y) + cur_x); }
+  Color &at(std::size_t cur_x, std::size_t cur_y)
+  {
+    return pixels_.at((width_ * cur_y) + cur_x);
+  }
 
   void ComputeRequirement() override
   {
@@ -204,12 +231,17 @@ struct Bitmap : ftxui::Node
   {
     for (std::size_t cur_x = 0; cur_x < width_; ++cur_x) {
       for (std::size_t cur_y = 0; cur_y < height_ / 2; ++cur_y) {
-        auto &pixel = screen.PixelAt(box_.x_min + static_cast<int>(cur_x), box_.y_min + static_cast<int>(cur_y));
+        auto &pixel = screen.PixelAt(box_.x_min + static_cast<int>(cur_x),
+          box_.y_min + static_cast<int>(cur_y));
         pixel.character = "▄";
         const auto &top_color = at(cur_x, cur_y * 2);
         const auto &bottom_color = at(cur_x, (cur_y * 2) + 1);
-        pixel.background_color = ftxui::Color{ top_color.R.get(), top_color.G.get(), top_color.B.get() };
-        pixel.foreground_color = ftxui::Color{ bottom_color.R.get(), bottom_color.G.get(), bottom_color.B.get() };
+        pixel.background_color = ftxui::Color{
+          top_color.r.get(), top_color.g.get(), top_color.b.get()
+        };
+        pixel.foreground_color = ftxui::Color{
+          bottom_color.r.get(), bottom_color.g.get(), bottom_color.b.get()
+        };
       }
     }
   }
@@ -218,20 +250,20 @@ struct Bitmap : ftxui::Node
 
   [[nodiscard]] auto height() const noexcept { return height_; }
 
-  [[nodiscard]] auto &data() noexcept { return pixels; }
+  [[nodiscard]] auto &data() noexcept { return pixels_; }
 
 private:
   std::size_t width_;
   std::size_t height_;
 
-  std::vector<Color> pixels = std::vector<Color>(width_ * height_, Color{});
+  std::vector<Color> pixels_ = std::vector<Color>(width_ * height_, Color{});
 };
 
 namespace {
-void game_iteration_canvas()
+void gameIterationCanvas()
 {
-  // this should probably have a `bitmap` helper function that does what cur_you expect
-  // similar to the other parts of FTXUI
+  // this should probably have a `bitmap` helper function that does what cur_you
+  // expect similar to the other parts of FTXUI
   auto bm = std::make_shared<Bitmap>(50, 50);// NOLINT magic numbers
   auto small_bm = std::make_shared<Bitmap>(6, 6);// NOLINT magic numbers
 
@@ -241,53 +273,63 @@ void game_iteration_canvas()
   std::size_t max_col = 0;
 
   // to do, add total game time clock also, not just current elapsed time
-  auto game_iteration = [&](const std::chrono::steady_clock::duration elapsed_time) {
-    // in here we simulate however much game time has elapsed. Update animations,
-    // run character AI, whatever, update stats, etc
+  auto game_iteration =
+    [&](const std::chrono::steady_clock::duration elapsed_time) {
+      // in here we simulate however much game time has elapsed. Update
+      // animations, run character AI, whatever, update stats, etc
 
-    // this isn't actually timing based for now, it's just updating the display however fast it can
-    fps = 1.0
-          / (static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(elapsed_time).count())
-             / 1'000'000.0);// NOLINT magic numbers
+      // this isn't actually timing based for now, it's just updating the
+      // display however fast it can
+      fps =
+        1.0
+        / (static_cast<double>(
+             std::chrono::duration_cast<std::chrono::microseconds>(elapsed_time)
+               .count())
+           / 1'000'000.0);// NOLINT magic numbers
 
-    for (std::size_t row = 0; row < max_row; ++row) {
-      for (std::size_t col = 0; col < bm->width(); ++col) { ++(bm->at(col, row).R); }
-    }
+      for (std::size_t row = 0; row < max_row; ++row) {
+        for (std::size_t col = 0; col < bm->width(); ++col) {
+          ++(bm->at(col, row).r);
+        }
+      }
 
-    for (std::size_t row = 0; row < bm->height(); ++row) {
-      for (std::size_t col = 0; col < max_col; ++col) { ++(bm->at(col, row).G); }
-    }
+      for (std::size_t row = 0; row < bm->height(); ++row) {
+        for (std::size_t col = 0; col < max_col; ++col) {
+          ++(bm->at(col, row).g);
+        }
+      }
 
-    // for the fun of it, let's have a second window doing interesting things
-    auto &small_bm_pixel =
-      small_bm->data().at(static_cast<std::size_t>(elapsed_time.count()) % small_bm->data().size());
+      // for the fun of it, let's have a second window doing interesting things
+      auto &small_bm_pixel =
+        small_bm->data().at(static_cast<std::size_t>(elapsed_time.count())
+                            % small_bm->data().size());
 
-    switch (elapsed_time.count() % 3) {
-    case 0:
-      small_bm_pixel.R += 11;// NOLINT Magic Number
-      break;
-    case 1:
-      small_bm_pixel.G += 11;// NOLINT Magic Number
-      break;
-    case 2:
-      small_bm_pixel.B += 11;// NOLINT Magic Number
-      break;
-    default:// literally impossible
+      switch (elapsed_time.count() % 3) {
+      case 0:
+        small_bm_pixel.r += 11;// NOLINT Magic Number
+        break;
+      case 1:
+        small_bm_pixel.g += 11;// NOLINT Magic Number
+        break;
+      case 2:
+        small_bm_pixel.b += 11;// NOLINT Magic Number
+        break;
+      default:// literally impossible
 #ifdef __GNUC__
-      __builtin_unreachable();
+        __builtin_unreachable();
 #elif _MSC_VER
-      __assume(false);
+        __assume(false);
 #else
-      std::terminate();// Fallback for other compilers
+        std::terminate();// Fallback for other compilers
 #endif
-    }
+      }
 
 
-    ++max_row;
-    if (max_row >= bm->height()) { max_row = 0; }
-    ++max_col;
-    if (max_col >= bm->width()) { max_col = 0; }
-  };
+      ++max_row;
+      if (max_row >= bm->height()) { max_row = 0; }
+      ++max_col;
+      if (max_col >= bm->width()) { max_col = 0; }
+    };
 
   auto screen = ftxui::ScreenInteractive::TerminalOutput();
 
@@ -337,7 +379,9 @@ void game_iteration_canvas()
 int main(int argc, const char **argv)
 {
   try {
-    CLI::App app{ fmt::format("{} version {}", Clock::cmake::project_name, Clock::cmake::project_version) };
+    CLI::App app{ fmt::format("{} version {}",
+      Clock::cmake::project_name,
+      Clock::cmake::project_version) };
 
     std::optional<std::string> message;
     app.add_option("-m,--message", message, "A message to print back out");
@@ -362,9 +406,9 @@ int main(int argc, const char **argv)
     }
 
     if (is_turn_based) {
-      consequence_game();
+      consequenceGame();
     } else {
-      game_iteration_canvas();
+      gameIterationCanvas();
     }
 
   } catch (const std::exception &e) {

--- a/src/sample_library/CMakeLists.txt
+++ b/src/sample_library/CMakeLists.txt
@@ -1,16 +1,15 @@
 include(GenerateExportHeader)
 
-
 add_library(sample_library sample_library.cpp)
-
-
 
 add_library(Clock::sample_library ALIAS sample_library)
 
 target_link_libraries(sample_library PRIVATE Clock_options Clock_warnings)
 
-target_include_directories(sample_library ${WARNING_GUARD} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-                                                                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
+target_include_directories(
+  sample_library ${WARNING_GUARD}
+  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
 
 target_compile_features(sample_library PUBLIC cxx_std_20)
 
@@ -20,7 +19,9 @@ set_target_properties(
              CXX_VISIBILITY_PRESET hidden
              VISIBILITY_INLINES_HIDDEN YES)
 
-generate_export_header(sample_library EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/Clock/sample_library_export.hpp)
+generate_export_header(
+  sample_library EXPORT_FILE_NAME
+  ${PROJECT_BINARY_DIR}/include/Clock/sample_library_export.hpp)
 
 if(NOT BUILD_SHARED_LIBS)
   target_compile_definitions(sample_library PUBLIC SAMPLE_LIBRARY_STATIC_DEFINE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,7 +27,8 @@ add_test(NAME cli.has_help COMMAND intro --help)
 # your program. Real world shows that this is the kind of simple mistake that is easy
 # to make, but also easy to test for.
 add_test(NAME cli.version_matches COMMAND intro --version)
-set_tests_properties(cli.version_matches PROPERTIES PASS_REGULAR_EXPRESSION "${PROJECT_VERSION}")
+set_tests_properties(cli.version_matches PROPERTIES PASS_REGULAR_EXPRESSION
+                                                    "${PROJECT_VERSION}")
 
 add_executable(tests tests.cpp)
 target_link_libraries(
@@ -41,7 +42,8 @@ if(WIN32 AND BUILD_SHARED_LIBS)
   add_custom_command(
     TARGET tests
     PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:tests> $<TARGET_FILE_DIR:tests>
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:tests>
+            $<TARGET_FILE_DIR:tests>
     COMMAND_EXPAND_LISTS)
 endif()
 
@@ -91,7 +93,8 @@ target_link_libraries(
           Clock::Clock_options
           Clock::sample_library
           Catch2::Catch2WithMain)
-target_compile_definitions(relaxed_constexpr_tests PRIVATE -DCATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
+target_compile_definitions(relaxed_constexpr_tests
+                           PRIVATE -DCATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
 
 catch_discover_tests(
   relaxed_constexpr_tests


### PR DESCRIPTION
This pull request includes updates to improve code formatting, enforce naming conventions, and refactor CMake configurations for consistency and maintainability. It also includes minor documentation updates to fix broken links and improve clarity.

### Code Formatting and Naming Conventions:
* [`.clang-format`](diffhunk://#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2L43-R43): Reduced `ColumnLimit` from 120 to 80 to enforce narrower line widths.
* [`.clang-tidy`](diffhunk://#diff-0534891fbc8b89b4c521057e7e8dff70d3cbeb822cc9991a3abad77848c289f8R30-R116): Added extensive identifier naming conventions for classes, members, variables, and other entities to improve code readability and consistency.
* [`.cmake-format.yaml`](diffhunk://#diff-b887201c256f2f90b6e21b0875c466e5109d0d41efc7bb6969886898961401c4L14-R14): Reduced `line_width` from 120 to 80 to align with the updated formatting standards.

### CMake Configuration Refactoring:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR64-R70): Refactored function calls to use consistent lowercase naming (e.g., `clock_setup_options` instead of `Clock_setup_options`) and improved message formatting for better readability. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR64-R70) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL135-R147)
* [`ProjectOptions.cmake`](diffhunk://#diff-5a49935bceabad2a6a37e3fa0955cef94678306574cd8d2ee7ff9a48dd9023f0L67-R78): Updated macro calls to use lowercase function names (e.g., `clock_supports_sanitizers`) and added support for enabling Doxygen documentation generation. [[1]](diffhunk://#diff-5a49935bceabad2a6a37e3fa0955cef94678306574cd8d2ee7ff9a48dd9023f0L67-R78) [[2]](diffhunk://#diff-5a49935bceabad2a6a37e3fa0955cef94678306574cd8d2ee7ff9a48dd9023f0L196-R249)

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R15): Fixed relative links to dependency and building documentation, and commented out the troubleshooting link.
* [`README_docker.md`](diffhunk://#diff-6d119c2234852d79921365d6396568554103b77fd00d8e88efd2c83a04e3d83cL12-R12): Updated links to point to the correct sections in related documentation files. [[1]](diffhunk://#diff-6d119c2234852d79921365d6396568554103b77fd00d8e88efd2c83a04e3d83cL12-R12) [[2]](diffhunk://#diff-6d119c2234852d79921365d6396568554103b77fd00d8e88efd2c83a04e3d83cL45-R45)